### PR TITLE
Add mobile footer for navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,55 +1,49 @@
-"use client";
-
 import "@mantine/core/styles.css";
-import { useDisclosure } from "@mantine/hooks";
+import { Group, AppShell, em } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
 import { Outlet } from "react-router-dom";
-import { Group, AppShell, Burger } from "@mantine/core";
 import HeaderTitle from "./components/HeaderTitle/HeaderTitle";
 import NavButtons from "./components/NavButtons/NavButtons";
-import Footer from "./components/Footer/Footer";
+// import Footer from "./components/Footer/Footer";
 import "./style.css";
 import ScrollToTop from "./utils/scrollToTop";
+import { BottomNavigation } from "./components/BottomNavigation/BottomNavigation";
 
 function App() {
+  // TODO choose more correct query
+  const isMobile = useMediaQuery(`(max-width: ${em(750)})`);
+
   // TODO add credit card info for checkout and adress
-  const [opened, { toggle }] = useDisclosure();
+
   return (
     <AppShell
       header={{ height: 60 }}
-      navbar={{
-        width: 300,
-        breakpoint: "sm",
-        collapsed: { desktop: true, mobile: !opened },
+      footer={{
+        height: 35,
+        collapsed: !isMobile,
       }}
       padding="md"
     >
       <ScrollToTop />
+
       <AppShell.Header>
         <Group h="100%" px="md">
-          <Burger
-            opened={opened}
-            onClick={toggle}
-            hiddenFrom="sm"
-            size="sm"
-            aria-label="Toggle navigation"
-          />
           <Group justify="space-between" style={{ flex: 1 }}>
             <HeaderTitle />
             <Group ml="xl" gap={0} visibleFrom="sm">
-              <NavButtons burgerToggle={toggle} />
+              <NavButtons />
             </Group>
           </Group>
         </Group>
       </AppShell.Header>
-      <AppShell.Navbar py="md" px={4}>
-        <NavButtons />
-      </AppShell.Navbar>
+
       <AppShell.Main>
         <Outlet />
       </AppShell.Main>
-      {/* <AppShell.Footer> */}
-      <Footer />
-      {/* </AppShell.Footer> */}
+
+      <AppShell.Footer>
+        <BottomNavigation />
+      </AppShell.Footer>
     </AppShell>
   );
 }

--- a/src/components/BottomNavigation/BottomNavigation.jsx
+++ b/src/components/BottomNavigation/BottomNavigation.jsx
@@ -1,0 +1,36 @@
+import { Transition, Button, Group } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { IconHome2, IconShoppingCart } from "@tabler/icons-react";
+
+const links = [
+  { link: "/", label: "Home", icon: <IconHome2 /> },
+  { link: "/cart", label: "Cart", icon: <IconShoppingCart /> },
+];
+export function BottomNavigation() {
+  const [mounted, setMounted] = useState(false);
+  const items = links.map((link) => (
+    <Button
+      component={Link}
+      variant="subtle"
+      key={link.label}
+      to={link.link}
+      //   className={classes.link}
+      leftSection={link.icon}
+    >
+      {link.label}
+    </Button>
+  ));
+  console.log(items);
+  return (
+    // <Transition
+    //   mounted={mounted}
+    //   transition="slide-up"
+    //   duration={400}
+    //   timingFunction="ease"
+    // >
+    <Group grow>{items}</Group>
+
+    // </Transition>
+  );
+}


### PR DESCRIPTION
This pull requests adds a mobile-only footer for navigating between shop and cart. Previously we had burger for that, but Burger would be more useful if we had a lot links. Right now, we only have 2, so it will be more than enough.